### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/app_vue3/src/stores/gallery.ts
+++ b/app_vue3/src/stores/gallery.ts
@@ -239,13 +239,13 @@ export const useGalleryStore = defineStore('gallery', {
             // Decode HTML entities in title (Reddit API returns encoded text)
             if (data.title) {
               data.title = data.title
-                .replace(/&amp;/g, '&')
                 .replace(/&lt;/g, '<')
                 .replace(/&gt;/g, '>')
                 .replace(/&quot;/g, '"')
                 .replace(/&#39;/g, "'")
                 .replace(/&#x27;/g, "'")
                 .replace(/&#x2F;/g, '/')
+                .replace(/&amp;/g, '&')
             }
             // Album / Gallery
             if (data.is_gallery && data.media_metadata) {


### PR DESCRIPTION
Potential fix for [https://github.com/modelorona/Scroll-It/security/code-scanning/3](https://github.com/modelorona/Scroll-It/security/code-scanning/3)

Decode HTML entities in a safe order by decoding `&amp;` **last**, not first.

Best fix (minimal behavior change): in `app_vue3/src/stores/gallery.ts`, reorder the replacement chain for `data.title` so named/numeric entities are decoded first, then decode ampersands at the end. This preserves existing manual decoding behavior while removing the double-unescape condition flagged by CodeQL.

Specifically, edit the block around lines 241–249:
- Keep the same entity mappings.
- Move `.replace(/&amp;/g, '&')` to the last replacement in the chain.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
